### PR TITLE
Track skip counts and ratios

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -77,6 +77,7 @@ struct GameState {
     int turns = 0;                   // number of turns elapsed
     std::array<int, 2> hand_limit;   // dynamic per-player hand limits
     int consecutive_skips = 0;       // consecutive skip-forced turns
+    int total_skips = 0;             // total skips executed this game
 };
 
 // Utility: remove a card id from a vector (order is not preserved but we keep
@@ -143,6 +144,7 @@ GameState initialise_game(const Settings& cfg, std::mt19937_64& rng) {
     state.turns = 0;
     state.hand_limit = {cfg.hand_size, cfg.hand_size};
     state.consecutive_skips = 0;
+    state.total_skips = 0;
 
     // Initial draw up to hand size from each deck.
     for (int p = 0; p < 2; ++p) {
@@ -617,6 +619,7 @@ struct TrialResult {
     bool completed = false;
     bool unwinnable = false;
     int turns = 0;
+    int skips = 0;
     std::optional<std::pair<int, int>> failure_reason;
 };
 
@@ -748,6 +751,7 @@ TrialResult play_single_game(const Settings& cfg, std::mt19937_64& rng, bool tra
 
         if (action_was_skip) {
             state.consecutive_skips++;
+            state.total_skips++;
         } else if (action_performed) {
             state.consecutive_skips = 0;
         }
@@ -769,6 +773,7 @@ TrialResult play_single_game(const Settings& cfg, std::mt19937_64& rng, bool tra
     }
 
     result.turns = state.turns;
+    result.skips = state.total_skips;
     return result;
 }
 
@@ -835,7 +840,14 @@ int main(int argc, char** argv) {
 
     if (cfg.trace) {
         TrialResult res = play_single_game(cfg, rng, true);
-        std::cout << "Trace complete. turns=" << res.turns;
+        std::cout << "Trace complete. turns=" << res.turns
+                  << " skips=" << res.skips;
+        if (res.turns > 0) {
+            std::ostringstream ratio_stream;
+            ratio_stream << std::fixed << std::setprecision(4)
+                         << static_cast<double>(res.skips) / res.turns;
+            std::cout << " skip_ratio=" << ratio_stream.str();
+        }
         if (res.completed) {
             std::cout << " result=success\n";
         } else if (res.unwinnable && res.failure_reason.has_value()) {
@@ -853,12 +865,18 @@ int main(int argc, char** argv) {
     int64_t successes = 0;
     long double sum_turns = 0.0L;
     long double sum_sq_turns = 0.0L;
+    long double sum_skips = 0.0L;
+    long double sum_skip_ratios = 0.0L;
     std::map<std::string, int64_t> failure_counts;
 
     for (int64_t t = 0; t < cfg.trials; ++t) {
         TrialResult res = play_single_game(cfg, rng, false);
         sum_turns += res.turns;
         sum_sq_turns += static_cast<long double>(res.turns) * res.turns;
+        sum_skips += res.skips;
+        if (res.turns > 0) {
+            sum_skip_ratios += static_cast<long double>(res.skips) / res.turns;
+        }
         if (res.completed) {
             ++successes;
             success_turns.push_back(res.turns);
@@ -908,6 +926,18 @@ int main(int argc, char** argv) {
               << " sd=" << static_cast<double>(sd) << std::setprecision(4)
               << " p50=" << quantile(0.5)
               << " p90=" << quantile(0.9) << "\n";
+
+    long double mean_skips = sum_skips / cfg.trials;
+    long double mean_skip_ratio = sum_skip_ratios / cfg.trials;
+    long double overall_skip_fraction =
+        sum_turns > 0 ? sum_skips / sum_turns : 0.0L;
+
+    std::cout << "mean_skips=" << std::setprecision(2)
+              << static_cast<double>(mean_skips)
+              << " mean_skip_ratio=" << std::setprecision(4)
+              << static_cast<double>(mean_skip_ratio)
+              << " overall_skip_fraction=" << static_cast<double>(overall_skip_fraction)
+              << std::setprecision(4) << "\n";
 
     if (!failure_counts.empty()) {
         std::cout << "failures_by_need:";


### PR DESCRIPTION
## Summary
- track a running total of skip actions within each simulated game
- surface skip totals in trace mode and report mean skip counts and ratios alongside turn statistics

## Testing
- g++ -std=c++17 main.cpp -o ladder_sim

------
https://chatgpt.com/codex/tasks/task_e_68d58bb319b8832482e21fc9e9290aa1